### PR TITLE
Use System Default Compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Predefined constants
-CC      = gcc
+CC      = cc
 TARGET  = file-rom-bin
 SRC_DIR = src
 OBJ_DIR = obj


### PR DESCRIPTION
Simply changes the compiler executable from `gcc` to the system's default compiler (`cc`), usually a symbolic link to `gcc` or another GNU compatible compiler such as `clang`.