### PR TITLE
Add Support for Building with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.zip
 *.7z
 obj/
+/build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,55 @@
+
+cmake_minimum_required(VERSION 3.20)
+
+project(gimp-rom-bin)
+
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type" FORCE)
+endif()
+
+include(FindPkgConfig)
+pkg_search_module(GLIB REQUIRED glib-2.0)
+pkg_search_module(GTK REQUIRED gtk+-2.0)
+pkg_search_module(GIMP REQUIRED gimp-2.0)
+pkg_search_module(GIMPUI REQUIRED gimpui-2.0)
+
+include_directories(
+	"${PROJECT_SOURCE_DIR}/src"
+	${GTK_INCLUDE_DIRS}
+	${GIMP_INCLUDE_DIRS}
+)
+
+# detect all source files dynamically
+file(GLOB_RECURSE SRC_FILES "${PROJECT_SOURCE_DIR}/src/*.c")
+
+add_executable(file-rom-bin ${SRC_FILES})
+target_link_libraries(
+	file-rom-bin PRIVATE
+	${GLIB_LIBRARIES}
+	${GTK_LIBRARIES}
+	${GIMP_LIBRARIES}
+	${GIMPUI_LIBRARIES}
+)
+
+if(WIN32)
+	set(CMAKE_EXE_LINKER_FLAGS "-mwindows")
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+	add_custom_command(
+		TARGET file-rom-bin POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E echo "Stripping runtime of debugging symbols ..."
+		COMMAND ${CMAKE_STRIP} --strip-debug "$<TARGET_FILE:file-rom-bin>"
+	)
+endif()
+
+# parse GIMP's major & minor versions
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" GIMP_API_VERSION "${GIMP_VERSION}")
+if(WIN32)
+	set(GIMP_PLUGINS_DIR "$ENV{APPDATA}/GIMP/${GIMP_API_VERSION}/plug-ins" CACHE PATH "Directory where GIMP's plugins are located")
+else()
+	set(GIMP_PLUGINS_DIR "$ENV{HOME}/.config/GIMP/${GIMP_API_VERSION}/plug-ins" CACHE PATH "Directory where GIMP's plugins are located")
+endif()
+
+# execute `cmake --install <build_path>` to install to GIMP plugin-ins directory
+install(TARGETS file-rom-bin RUNTIME DESTINATION "${GIMP_PLUGINS_DIR}")

--- a/README.md
+++ b/README.md
@@ -45,7 +45,17 @@ If GIMP & build tools not yet installed:
  
 Then: 
 * cd gimp-rom-bin
+
+Build using GNU make:
 * make
+
+Build using CMake:
+* cmake ./
+* cmake --build ./
+
+Build using CMake in subdirectory:
+* cmake -B build/ ./
+* cmake --build build/
 
 Then copy the resulting "file-rom-bin" to your GIMP plugin folder, depends on version
 


### PR DESCRIPTION
Adds [CMake build system](https://cmake.org/) support.

Usage examples:
```sh
# build with debugging symbols
$ cmake ./
$ cmake --build ./

# build without debugging symbols
$ cmake -DCMAKE_BUILD_TYPE=Release ./
$ cmake --build ./

# build in sub-directory
$ cmake -B build/ -DCMAKE_BUILD_TYPE=Release ./
$ cmake --build build/

# install to GIMP plug-ins directory
$ cmake --install build/
```